### PR TITLE
Improved undo and redo 

### DIFF
--- a/src/main/java/CreateShape.java
+++ b/src/main/java/CreateShape.java
@@ -1,8 +1,7 @@
-public abstract class CreateShape extends Command {
+public abstract class CreateShape extends ShapeCommand {
     protected Document document;
     protected int x;
     protected int y;
-    private Shape shape;
 
     public CreateShape(Document document, int x, int y) {
         super();

--- a/src/main/java/Document.java
+++ b/src/main/java/Document.java
@@ -1,13 +1,23 @@
+import sun.plugin.dom.exception.InvalidStateException;
+
+import java.io.InvalidClassException;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Stack;
 import java.util.stream.Collectors;
 import java.io.Serializable;
 
-public class Document implements Serializable {
-    private List<Shape> shapes = new ArrayList<>();
-    private Stack<Command> commands = new Stack<>();
-    private Stack<Command> undos = new Stack<>();
+public class Document {
+    private List<Shape> shapes;
+    private LinkedList<Command> commands;
+    private int commandIndex;
+
+    public Document() {
+        shapes = new ArrayList<>();
+        commands = new LinkedList<>();
+        commandIndex = -1;
+    }
 
     public void addShape(Shape shape) {
         shapes.add(shape);
@@ -25,17 +35,42 @@ public class Document implements Serializable {
     }
 
     public void execute(Command cmd) {
-        commands.push(cmd);
+        commands.add(++commandIndex, cmd);
         cmd.execute();
     }
 
     public void undo() {
-        Command lastCommand = commands.pop();
-        undos.push(lastCommand);
+        if(commandIndex < 0)
+            throw new InvalidStateException("Nothing to undo...");
+
+        Command lastCommand = commands.get(commandIndex);
+        commandIndex--;
         lastCommand.undo();
     }
 
     public void redo() {
-        execute(undos.pop());
+        if(commandIndex + 1 >= commands.size())
+            throw new InvalidStateException("Nothing to redo...");
+
+        commandIndex++;
+        Command nextCommand = commands.get(commandIndex);
+        if(!isCommandValid(nextCommand))
+            throw new InvalidStateException("Can not apply transformations over deleted shape...");
+
+        nextCommand.execute();
+    }
+
+    public void redoAll() {
+        for(int i = commandIndex; i < commands.size() - 1; i++) {
+            redo();
+        }
+    }
+
+    private boolean isCommandValid(Command cmd) {
+        if(cmd instanceof TransformShapeCommand) {
+            if (!shapes.contains(((TransformShapeCommand) cmd).getShape()))
+                return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/ShapeCommand.java
+++ b/src/main/java/ShapeCommand.java
@@ -1,0 +1,7 @@
+public abstract class ShapeCommand extends Command {
+    protected Shape shape;
+
+    public Shape getShape() {
+        return shape;
+    }
+}

--- a/src/main/java/TransformShapeCommand.java
+++ b/src/main/java/TransformShapeCommand.java
@@ -1,0 +1,5 @@
+/**
+ * Created by joaos on 30/03/2017.
+ */
+public abstract class TransformShapeCommand extends ShapeCommand {
+}

--- a/src/test/java/DocumentTest.java
+++ b/src/test/java/DocumentTest.java
@@ -1,0 +1,102 @@
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Created by joaos on 30/03/2017.
+ */
+public class DocumentTest {
+
+    Document d1;
+
+    @Before
+    public void setup() {
+        d1 = new Document();
+    }
+
+    @Test
+    public void execute() throws Exception {
+        Assert.assertEquals(0, d1.getShapes().size());
+
+        List<Command> cmds = Arrays.asList(
+                new CreateCircle(d1, 100, 100),
+                new CreateCircle(d1, 300, 300),
+                new CreateCircle(d1, 500, 100),
+                new CreateRectangle(d1, 20, 20));
+        for(Command cmd : cmds)
+            d1.execute(cmd);
+
+        Assert.assertEquals(4, d1.getShapes().size());
+    }
+
+    @Test
+    public void undo() throws Exception {
+        Assert.assertEquals(0, d1.getShapes().size());
+
+        List<Command> cmds = Arrays.asList(
+                new CreateCircle(d1, 100, 100),
+                new CreateCircle(d1, 300, 300),
+                new CreateCircle(d1, 500, 100),
+                new CreateRectangle(d1, 20, 20));
+        for(Command cmd : cmds)
+            d1.execute(cmd);
+
+        Assert.assertEquals(4, d1.getShapes().size());
+
+        d1.undo();
+
+        Assert.assertEquals(3, d1.getShapes().size());
+
+        d1.undo();
+
+        Assert.assertEquals(2, d1.getShapes().size());
+    }
+
+    @Test
+    public void redo() throws Exception {
+        Assert.assertEquals(0, d1.getShapes().size());
+
+        List<Command> cmds = Arrays.asList(
+                new CreateCircle(d1, 500, 100),
+                new CreateRectangle(d1, 20, 20));
+        for(Command cmd : cmds)
+            d1.execute(cmd);
+
+        Assert.assertEquals(2, d1.getShapes().size());
+
+        d1.undo();
+
+        Assert.assertEquals(1, d1.getShapes().size());
+
+        d1.redo();
+
+        Assert.assertEquals(2, d1.getShapes().size());
+    }
+
+    @Test
+    public void redoAll() throws Exception {
+        Assert.assertEquals(0, d1.getShapes().size());
+
+        List<Command> cmds = Arrays.asList(
+                new CreateCircle(d1, 500, 100),
+                new CreateRectangle(d1, 20, 20));
+        for(Command cmd : cmds)
+            d1.execute(cmd);
+
+        Assert.assertEquals(2, d1.getShapes().size());
+
+        d1.undo();
+
+        Assert.assertEquals(1, d1.getShapes().size());
+
+        d1.execute(new CreateCircle(d1, 50, 15));
+
+        Assert.assertEquals(2, d1.getShapes().size());
+
+        d1.redo();
+
+        Assert.assertEquals(3, d1.getShapes().size());
+    }
+}


### PR DESCRIPTION
It is now possible to undo several commands, execute a new one and then redo all the following commands.

Created two abstract classes for commands "ShapeCommand" and "TransformShapeCommand" because when redoing we can not apply a transformation over a non existing shape, so when the next command is a transformation we do not apply it.